### PR TITLE
Rubocop style fixes

### DIFF
--- a/lib/bitex/api.rb
+++ b/lib/bitex/api.rb
@@ -2,6 +2,9 @@ module Bitex
   class ApiError < StandardError
   end
 
+  ##
+  # Documentation here!
+  #
   class Api
     def self.grab_curl
       if @curl

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -20,7 +20,11 @@ module Bitex
           else
             raw_value
           end
-          thing.send("#{key}=", value) rescue nil
+          begin
+            thing.send("#{key}=", value)
+          rescue StandarError
+            nil
+          end
         end
       end
     end

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -20,9 +20,10 @@ module Bitex
           else
             raw_value
           end
+
           begin
             thing.send("#{key}=", value)
-          rescue StandarError
+          rescue NoMethodError
             nil
           end
         end

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -1,4 +1,7 @@
 module Bitex
+  ##
+  # Documentation here!
+  #
   class Payment
     attr_accessor :id, :user_id, :amount, :currency_id, :expected_quantity,
       :previous_expected_quantity, :confirmed_quantity, :unconfirmed_quantity,

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -26,26 +26,32 @@ module Bitex
     end
 
     def self.create!(params)
-      from_json(Api.private(:post, "/private/payments", params))
+      from_json(Api.private(:post, base_uri, params))
     end
 
     def self.find(id)
-      from_json(Api.private(:get, "/private/payments/#{id}"))
+      from_json(Api.private(:get, "#{base_uri}/#{id}"))
     end
 
     def self.all
-      Api.private(:get, "/private/payments").collect{|x| from_json(x) }
+      Api.private(:get, base_uri).collect{|x| from_json(x) }
     end
     
     # Validate a callback and parse the given payment from it.
     # Returns nil if the callback was invalid.
     def self.from_callback(callback_params)
-      from_json(callback_params["payment"]) if callback_params["api_key"] == Bitex.api_key
+      from_json(callback_params['payment']) if callback_params['api_key'] == Bitex.api_key
     end
 
     # Sets up the web-pos
     def self.pos_setup!(params)
-      Api.private(:post, "/private/payments/pos_setup", params)
+      Api.private(:post, "#{base_uri}/pos_setup", params)
+    end
+
+    private_class_method
+
+    def self.base_uri
+      '/private/payments'
     end
   end
 end

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -15,7 +15,7 @@ module Bitex
         json.each do |key,raw_value|
           next if raw_value.nil?
 
-          value = if [:valid_until, :quote_valid_until, :last_quoted_on].include?(key.to_sym)
+          value = if %i[valid_until quote_valid_until last_quoted_on].include?(key.to_sym)
             Time.at(raw_value)
           else
             raw_value

--- a/lib/bitex/rates.rb
+++ b/lib/bitex/rates.rb
@@ -12,7 +12,7 @@ module Bitex
     # Full exchange rates tree, gets cached locally for 60 seconds.
     def self.tree
       if @tree.nil? || @last_tree_fetch.to_i < (Time.now.to_i - 60)
-        @tree = Api.public("/rates/tree").deep_symbolize_keys
+        @tree = Api.public('/rates/tree').deep_symbolize_keys
         @last_tree_fetch = Time.now.to_i
       end
       @tree

--- a/spec/payment_spec.rb
+++ b/spec/payment_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
 
 describe Bitex::Payment do
-  before :each do 
-    Bitex.api_key = 'valid_api_key'
-  end
+  before(:each) { Bitex.api_key = 'valid_api_key' }
 
   let(:params_for_create) do
     {
       currency_id: 3,
       amount: 1000,
-      callback_url: "https://example.com/ipn",
+      callback_url: 'https://example.com/ipn',
       keep: 25.0,
-      customer_reference: "An Alto latte, no sugar",
-      merchant_reference: "invoice#1234",
+      customer_reference: 'An Alto latte, no sugar',
+      merchant_reference: 'invoice#1234'
     }
   end
-  
+
   let(:as_json) do
     {
       id: 1,
@@ -29,21 +27,23 @@ describe Bitex::Payment do
       valid_until:  1430226201,
       quote_valid_until:  1430226201,
       last_quoted_on: 1430220201,
-      status: "pending",
-      address: { 
-        "id": 4,
-        "public_address": "1ABC...",
+      status: 'pending',
+      address: {
+        'id': 4,
+        'public_address': '1ABC...',
       },
       settlement_currency_id: 2,
       settlement_amount:  100,
       keep: 1.5,
-      merchant_reference: "Invoice#1234",
-      customer_reference: "Frappuchino",
+      merchant_reference: 'Invoice#1234',
+      customer_reference: 'Frappuchino',
     }
   end
-  
+
+  let(:as_malformed_json) { { bad_key: 'i should not be setted' } }
+
   let(:callback_params) do
-    { "api_key" => 'valid_api_key', "payment" => as_json}
+    { 'api_key' => 'valid_api_key', 'payment' => as_json }
   end
 
   {
@@ -56,64 +56,70 @@ describe Bitex::Payment do
     confirmed_quantity: 0.0,
     unconfirmed_quantity: 0.0,
     valid_until:  Time.at(1430226201),
-    quote_valid_until:  Time.at(1430226201),
-    last_quoted_on: Time.at(1430220201),
-    status: "pending",
-    address: { 
-      "id": 4,
-      "public_address": "1ABC...",
+    quote_valid_until:  Time.at(1_430_226_201),
+    last_quoted_on: Time.at(1_430_220_201),
+    status: 'pending',
+    address: {
+      'id': 4,
+      'public_address': '1ABC...',
     },
     settlement_currency_id: 2,
     settlement_amount:  100,
     keep: 1.5,
-    merchant_reference: "Invoice#1234",
-    customer_reference: "Frappuchino",
+    merchant_reference: 'Invoice#1234',
+    customer_reference: 'Frappuchino'
   }.each do |field, value|
-    it "sets #{field}" do
-      subject.class.from_json(as_json).send(field).should == value
+      it "sets #{field}" do
+        subject.class.from_json(as_json).send(field).should eq value
+      end
+
+      it "not sets #{field}" do
+        subject.class.from_json(as_malformed_json).send(field).should be_nil
+      end
     end
-  end
 
   it 'creates a new payment' do
-    stub_private(:post, "/private/payments", 'payment',
-      params_for_create)
-    Bitex::Payment.create!(params_for_create)
-      .should be_a Bitex::Payment
+    stub_private(:post, '/private/payments', 'payment', params_for_create)
+
+    Bitex::Payment.create!(params_for_create).should be_a Bitex::Payment
   end
-  
+
   it 'finds a single payment' do
     stub_private(:get, '/private/payments/1', 'payment')
+
     Bitex::Payment.find(1).should be_a Bitex::Payment
   end
-  
+
   it 'lists all payments' do
     stub_private(:get, '/private/payments', 'payments')
+
     payments = Bitex::Payment.all
+
     payments.should be_an Array
-    payments.first.should be_a Bitex::Payment
+    payments.all? { |payment| payment.should be_a Bitex::Payment }
   end
-  
+
   it 'accepts a callback' do
     Bitex::Payment
       .from_callback(callback_params)
       .should be_a Bitex::Payment
   end
-  
+
   it 'raises exception if invalid api key' do
     Bitex::Payment
-      .from_callback(callback_params.merge("api_key" => 'bogus'))
+      .from_callback(callback_params.merge('api_key' => 'bogus'))
       .should be_nil
   end
-  
+
   it 'configures store' do
-    pos_params = {  
-      "merchant_name" => "Tierra Buena",
-      "merchant_slug" => "tierrabuena",
-      "merchant_logo" => "https://t.co/logo.png",
-      "merchant_keep" => 0,
+    pos_params = {
+      'merchant_name' => 'Tierra Buena',
+      'merchant_slug' => 'tierrabuena',
+      'merchant_logo' => 'https://t.co/logo.png',
+      'merchant_keep' => 0
     }
-    stub_private(:post, "/private/payments/pos_setup", 'pos_setup', pos_params.dup)
-    Bitex::Payment.pos_setup!(pos_params)
-      .should == pos_params
+    stub_private(:post, '/private/payments/pos_setup', 'pos_setup', pos_params.dup)
+
+    Bitex::Payment.pos_setup!(pos_params).should == pos_params
   end
 end


### PR DESCRIPTION
Add missing top-level class documentation comment
Prefer single-quoted strings when you don't need string interpolation…
Use %i or %I for an array of symbols.
Avoid using rescue in its modifier formand rescuing without specifyin…