### PR TITLE
Rubocop layout fixes

### DIFF
--- a/lib/bitex/api.rb
+++ b/lib/bitex/api.rb
@@ -49,7 +49,7 @@ module Bitex
       curl
     end
 
-    def self.public(path, options = {})
+    def self.public(path, _options = {})
       response = curl(:GET, path)
       JSON.parse(response.body)
     end

--- a/lib/bitex/market_data.rb
+++ b/lib/bitex/market_data.rb
@@ -24,7 +24,7 @@ module Bitex
     def self.transactions
       api_get('/market/transactions')
     end
-    
+
     # Returns a list of lists with aggregated transaction data for each hour
     # from the last 24 hours.
     # @see https://bitex.la/developers#last_24_hours

--- a/lib/bitex/market_data.rb
+++ b/lib/bitex/market_data.rb
@@ -2,7 +2,6 @@ module Bitex
   # Public market data for a specie, do not use directly, use
   # {BitcoinMarketData} instead.
   class MarketData
-
     # The species currency ticker conveniently formatted as a ruby Hash with
     # symbolized keys.
     # @see https://bitex.la/developers#ticker

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -1,10 +1,8 @@
 module Bitex
   class Payment
-    attr_accessor %i[
-      id user_id amount currency_id expected_quantity previous_expected_quantity confirmed_quantity unconfirmed_quantity
-      valid_until quote_valid_until last_quoted_on status address settlement_currency_id settlement_amount keep
-      merchant_reference customer_reference
-    ]
+    attr_accessor :id, :user_id, :amount, :currency_id, :expected_quantity, :previous_expected_quantity, :confirmed_quantity,
+                  :unconfirmed_quantity, :valid_until, :quote_valid_until, :last_quoted_on, :status, :address,
+                  :settlement_currency_id, :settlement_amount, :keep, :merchant_reference, :customer_reference
 
     # @visibility private
     def self.from_json(json)

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -1,10 +1,10 @@
 module Bitex
   class Payment
-    attr_accessor :id, :user_id, :amount, :currency_id, :expected_quantity,
-      :previous_expected_quantity, :confirmed_quantity, :unconfirmed_quantity,
-      :valid_until, :quote_valid_until, :last_quoted_on, :status, :address,
-      :settlement_currency_id, :settlement_amount, :keep, :merchant_reference,
-      :customer_reference
+    attr_accessor %i[
+      id user_id amount currency_id expected_quantity previous_expected_quantity confirmed_quantity unconfirmed_quantity
+      valid_until quote_valid_until last_quoted_on status address settlement_currency_id settlement_amount keep
+      merchant_reference customer_reference
+    ]
 
     # @visibility private
     def self.from_json(json)

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -33,7 +33,7 @@ module Bitex
     def self.all
       Api.private(:get, "/private/payments").collect{|x| from_json(x) }
     end
-    
+
     # Validate a callback and parse the given payment from it.
     # Returns nil if the callback was invalid.
     def self.from_callback(callback_params)

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -12,11 +12,13 @@ module Bitex
         json.each do |key, raw_value|
           next if raw_value.nil?
 
-          value = if [:valid_until, :quote_valid_until, :last_quoted_on].include?(key.to_sym)
-            Time.at(raw_value)
-          else
-            raw_value
-          end
+          value =
+            if [:valid_until, :quote_valid_until, :last_quoted_on].include?(key.to_sym)
+              Time.at(raw_value)
+            else
+              raw_value
+            end
+
           thing.send("#{key}=", value) rescue nil
         end
       end

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -20,8 +20,6 @@ module Bitex
               raw_value
             end
 
-          thing.send("#{key}=", value) rescue nil
-
           begin
             thing.send("#{key}=", value)
           rescue NoMethodError

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -46,4 +46,3 @@ module Bitex
     end
   end
 end
-

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -9,7 +9,7 @@ module Bitex
     # @visibility private
     def self.from_json(json)
       new.tap do |thing|
-        json.each do |key,raw_value|
+        json.each do |key, raw_value|
           next if raw_value.nil?
 
           value = if [:valid_until, :quote_valid_until, :last_quoted_on].include?(key.to_sym)

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -31,7 +31,7 @@ module Bitex
     end
 
     def self.all
-      Api.private(:get, "/private/payments").collect{|x| from_json(x) }
+      Api.private(:get, "/private/payments").map { |p| from_json(p) }
     end
 
     # Validate a callback and parse the given payment from it.

--- a/lib/bitex/payment.rb
+++ b/lib/bitex/payment.rb
@@ -40,11 +40,7 @@ module Bitex
     end
 
     def self.all
-<<<<<<< HEAD
-      Api.private(:get, "/private/payments").map { |p| from_json(p) }
-=======
       Api.private(:get, base_uri).collect{|x| from_json(x) }
->>>>>>> 89326889afaa8ebee4e30c340da2d8b1166d99f6
     end
 
     # Validate a callback and parse the given payment from it.

--- a/lib/bitex/rates.rb
+++ b/lib/bitex/rates.rb
@@ -17,9 +17,9 @@ module Bitex
       end
       @tree
     end
-    
+
     def self.clear_tree_cache
-      @tree = nil 
+      @tree = nil
       @last_tree_fetch = nil
     end
 
@@ -40,7 +40,7 @@ module Bitex
       end
       value
     end
-    
+
     def self.calculate_path_backwards(path, value)
       value = value.to_d
       path_to_calculator(path).each do |step|
@@ -59,7 +59,7 @@ module Bitex
       end
       value
     end
-  
+
     def self.path_to_calculator(path)
       steps = tree
       begin

--- a/lib/bitex/rates.rb
+++ b/lib/bitex/rates.rb
@@ -52,8 +52,7 @@ module Bitex
         when :fixed_fee
           value += step[:amount].to_d
         when :minimum_fee
-          value = [value + step[:minimum].to_d,
-            value / (1 - (step[:percentage].to_d / 100.to_d))].max
+          value = [value + step[:minimum].to_d, value / (1 - (step[:percentage].to_d / 100.to_d))].max
         end
       end
       value

--- a/lib/bitex/rates.rb
+++ b/lib/bitex/rates.rb
@@ -8,7 +8,6 @@ module Bitex
   #     Bitex::Rates.calculate_back([:ars, :cash, :usd, :bitex, :more_mt], 200)
   # @see https://bitex.la/developers#rates
   class Rates
-
     # Full exchange rates tree, gets cached locally for 60 seconds.
     def self.tree
       if @tree.nil? || @last_tree_fetch.to_i < (Time.now.to_i - 60)

--- a/lib/bitex/specie_deposit.rb
+++ b/lib/bitex/specie_deposit.rb
@@ -20,7 +20,7 @@ module Bitex
     # @visibility private
     def self.from_json(json)
       Api.from_json(new, json) do |thing|
-        thing.specie =  { 1 => :btc }[json[3]]
+        thing.specie = { 1 => :btc }[json[3]]
         thing.quantity = (json[4] || 0).to_d
       end
     end

--- a/lib/bitex/specie_withdrawal.rb
+++ b/lib/bitex/specie_withdrawal.rb
@@ -52,7 +52,7 @@ module Bitex
     # @visibility private
     def self.from_json(json)
       Api.from_json(new, json) do |thing|
-        thing.specie =  { 1 => :btc }[json[3]]
+        thing.specie = { 1 => :btc }[json[3]]
         thing.quantity = (json[4].presence || 0).to_d
         thing.status = statuses[json[5]]
         thing.reason = reasons[json[6]]

--- a/lib/bitex/specie_withdrawal.rb
+++ b/lib/bitex/specie_withdrawal.rb
@@ -46,7 +46,7 @@ module Bitex
     attr_accessor :kyc_profile_id
 
     # @!attribute transaction_id
-    #   @return [String] Network transaction id, if available. 
+    #   @return [String] Network transaction id, if available.
     attr_accessor :transaction_id
 
     # @visibility private


### PR DESCRIPTION
remove extra spacing
remove trailing whitespace
use _ or _options as an argument name to indicate that it won't be used.
clean extra empty line detected at class body beginning.
Align the elements of an array literal if they span more than one line.
remove trailing blank lines detected.
add missing space between {, |, and }.
Align the parameters of a method call if they span more than one line.
add space missing after comma.
align if indentation.